### PR TITLE
Odekake cleanup

### DIFF
--- a/CWE/CWE.vcxproj
+++ b/CWE/CWE.vcxproj
@@ -269,6 +269,7 @@
     <ClInclude Include="al_minimal.h" />
     <ClInclude Include="al_msg_font.h" />
     <ClInclude Include="al_msg_win.h" />
+    <ClInclude Include="al_ode_menu.h" />
     <ClInclude Include="al_parts.h" />
     <ClInclude Include="al_misc.h" />
     <ClInclude Include="AL_ModAPI.h" />

--- a/CWE/al_customization.cpp
+++ b/CWE/al_customization.cpp
@@ -29,6 +29,23 @@
 #include "ui/al_ortho.h"
 #include "al_ode_guide.h"
 
+#include "al_ode_menu.h"
+
+// the menu entry
+static void AL_OdekakeCustomization(ODE_MENU_MASTER_WORK* a1);
+
+CWE_API_ODEKAKE_ENTRY OdekakeCustomizationEntry = {
+	AL_OdekakeCustomization, 
+	nullptr, 
+	ODE_FLAGS_REQUIRE_CHAO, 
+	&stru_11BA528[32],
+	&stru_11BA528[8],
+	&stru_11BA528[9],
+	&stru_11BA528[22],
+	&stru_11BA528[23], 
+	1.0, 1.0, 0.5, 0.5 
+};
+
 //constants
 const int HatsSubMenuCount = AccessoryTypeCount + 1; //(accessories + vanilla hat)
 const std::string baseLayerName = "base";
@@ -429,8 +446,7 @@ ObjectMaster* pChao;
 UIController* customizationController = nullptr;
 ObjectMaster* largeBar = 0;
 
-void __cdecl AL_OdekakeCustomization(ODE_MENU_MASTER_WORK* a1)
-{	
+static void AL_OdekakeCustomization(ODE_MENU_MASTER_WORK* a1) {	
 	NJS_VECTOR posIn = { 130, 190, -30 }, posOut;
 	switch (a1->mode)
 	{
@@ -536,27 +552,8 @@ void __cdecl AL_OdekakeCustomization(ODE_MENU_MASTER_WORK* a1)
 		delete customizationController;
 		customizationController = 0;
 
-		AL_OdekakeMenuMaster_Data_ptr->NextStage = 0;
-		if (AL_OdekakeMenuMaster_Data_ptr)
-		{
-			void(__cdecl * v0)(ODE_MENU_MASTER_WORK*); // eax
-			v0 = AL_OdekakeMenuMaster_Data_ptr->mfStageExit;
-			if (v0)
-			{
-				//	v0(AL_OdekakeMenuMaster_Data_ptr);
-			}
-			AL_OdekakeMenuMaster_Data_ptr->PreStage = AL_OdekakeMenuMaster_Data_ptr->CurrStage;
-			AL_OdekakeMenuMaster_Data_ptr->CurrStage = AL_OdekakeMenuMaster_Data_ptr->NextStage;
-			AL_OdekakeMenuMaster_Data_ptr->mode = 0;
-			AL_OdekakeMenuMaster_Data_ptr->timer = 0;
-			AL_OdekakeMenuMaster_Data_ptr->subtimer = 0;
-			AL_OdekakeMenuMaster_Data_ptr->state = 0;
-			AL_OdekakeMenuMaster_Data_ptr->cursorX = 0;
-			AL_OdekakeMenuMaster_Data_ptr->cursorY = 0;
-			AL_OdekakeMenuMaster_Data_ptr->EndFlag = 0;
-			AL_OdekakeMenuMaster_Data_ptr->mfStageExit = 0;
-			AL_OdekakeMenuMaster_Data_ptr->mpStageWork = 0;
-		}
+		AL_OdeMenuSetNextStage(0);
+		AL_OdeMenuChangeStage();
 		break;
 	}
 }

--- a/CWE/al_ode_guest.cpp
+++ b/CWE/al_ode_guest.cpp
@@ -6,6 +6,21 @@
 #include <cstdio>
 #include "al_ode_guide.h"
 
+#include "al_texlist.h"
+
+#include "al_ode_menu.h"
+
+static void AL_OdekakeGuest(ODE_MENU_MASTER_WORK* a1);
+
+static ChaoHudThingB GuestMenu[] = {
+	{1, 128, 32, 0, 0.01f, 0.5f, 0.5f, &AL_ODE_GUEST_TEXLIST, 0}, //text
+	{1, 128, 32, 136.0f / 256.0f, 0.01f, 1, 0.5f, &AL_ODE_GUEST_TEXLIST, 0}, //grey text
+	{1, 40, 40, 0, 0, 0.99f, 1, &AL_ODE_GUEST_TEXLIST, 1}, //icon
+	{1, 48, 48, 0, 0, 0.99f, 1, &AL_ODE_GUEST_TEXLIST, 2}, //icon black and white
+};
+
+CWE_API_ODEKAKE_ENTRY OdekakeGuestEntry = { AL_OdekakeGuest, nullptr, ODE_FLAGS_REQUIRE_CHAO, &GuestMenu[2],&GuestMenu[0],&GuestMenu[1],&GuestMenu[3] , &GuestMenu[0], 1.0, 1.0, 0.5, 0.5 };
+
 //please please please clean this up
 const int someUIProjectionCodeCopyPtr = 0x0055A060;
 void someUIProjectionCodeCopy(NJS_VECTOR* a1, NJS_VECTOR* a2)
@@ -18,8 +33,8 @@ void someUIProjectionCodeCopy(NJS_VECTOR* a1, NJS_VECTOR* a2)
 	}
 }
 
-ObjectMaster* pGuestChao = 0;
-void AL_OdekakeGuest(ODE_MENU_MASTER_WORK* a1)
+static ObjectMaster* pGuestChao = NULL;
+static void AL_OdekakeGuest(ODE_MENU_MASTER_WORK* a1)
 {
 	NJS_VECTOR posIn = { 240, 300, -25 };
 
@@ -66,19 +81,8 @@ void AL_OdekakeGuest(ODE_MENU_MASTER_WORK* a1)
 		if (AL_OdekakeMenuMaster_Data_ptr->timer > 60) {
 			AlMsgWarnDelete(0);
 
-			AL_OdekakeMenuMaster_Data_ptr->NextStage = 0;
-
-			AL_OdekakeMenuMaster_Data_ptr->PreStage = AL_OdekakeMenuMaster_Data_ptr->CurrStage;
-			AL_OdekakeMenuMaster_Data_ptr->CurrStage = AL_OdekakeMenuMaster_Data_ptr->NextStage;
-			AL_OdekakeMenuMaster_Data_ptr->mode = 0;
-			AL_OdekakeMenuMaster_Data_ptr->timer = 0;
-			AL_OdekakeMenuMaster_Data_ptr->subtimer = 0;
-			AL_OdekakeMenuMaster_Data_ptr->state = 0;
-			AL_OdekakeMenuMaster_Data_ptr->cursorX = 0;
-			AL_OdekakeMenuMaster_Data_ptr->cursorY = 2;
-			AL_OdekakeMenuMaster_Data_ptr->EndFlag = 0;
-			AL_OdekakeMenuMaster_Data_ptr->mfStageExit = 0;
-			AL_OdekakeMenuMaster_Data_ptr->mpStageWork = 0;			
+			AL_OdeMenuSetNextStage(0);
+			AL_OdeMenuChangeStage();
 		}
 		break;
 	}

--- a/CWE/al_ode_hikkoshi.cpp
+++ b/CWE/al_ode_hikkoshi.cpp
@@ -7,6 +7,21 @@
 #include <cstdio>
 #include "ChaoMain.h"
 #include "al_ode_guide.h"
+#include "al_ode_menu.h"
+
+static void AL_OdekakeMove(ODE_MENU_MASTER_WORK* a1);
+
+CWE_API_ODEKAKE_ENTRY OdakakeMoveEntry = {
+	AL_OdekakeMove, 
+	nullptr, 
+	ODE_FLAGS_REQUIRE_NO_CHAO , 
+	&stru_11BA528[31],
+	&stru_11BA528[6],
+	&stru_11BA528[7],
+	&stru_11BA528[20],
+	&stru_11BA528[21], 
+	1.0, 1.0, 0.5, 0.0 
+};
 
 #pragma pack(push, 8)
 struct SelectMenuThing
@@ -116,7 +131,7 @@ VoidFunc(al_confirmsave_load_zero, 0x00530230);
 
 // to check the current save we extract the "save number" from the filename
 // multiSaveIndices[] is also this array
-char GetMultiSaveIndex() {
+static char GetMultiSaveIndex() {
 	// ecw's multisaves are longer than the vanilla/cwe ones, that's how we detect if it's ecw's or not
 	if (strlen(selectedSavePath) == strlen(CurrentChaoSaveFileString)) {
 		// if length matches, we're in a vanilla/cwe file
@@ -143,7 +158,7 @@ char GetMultiSaveIndex() {
 	return '0' + numberConverted;
 }
 
-void AL_SaveSecondFile() {
+static void AL_SaveSecondFile() {
 	WriteChaoSaveChecksum((char*)SecondChaoSaveFilePointer);
 
 	// i don't remember why the offset we need is exactly 0x3040 but... yeah
@@ -158,7 +173,7 @@ void AL_SaveSecondFile() {
 	}
 }
 
-ChaoData* AL_GetSecondFileChao() {
+static ChaoData* AL_GetSecondFileChao() {
 	int backup = ChaoSaveIndexThing;
 	ChaoSaveIndexThing = 1;
 	ChaoData* data = AL_GetNewChaoSaveInfo();
@@ -166,7 +181,7 @@ ChaoData* AL_GetSecondFileChao() {
 	return data;
 }
 
-void AL_HikkoshiMenuExecutor(ObjectMaster *a1) {
+static void AL_HikkoshiMenuExecutor(ObjectMaster *a1) {
 	if (a1->Data1.Entity->Action == 0) {
 		if (*(int*)0x1AED254 == 2) { // menu is quitting 
 			AL_OdekakeMenuMaster_Data_ptr->EndFlag = 1;
@@ -269,7 +284,7 @@ static ChaoHudThingB HikkoshiUI[] = {
 // the generic menu sprite array used throughout the odekake menus
 DataArray(ChaoHudThingB, MenuArray, 0x11BA528, 0x61);
 
-void AL_HikkoshiMenuDisplayer(ObjectMaster* a1) {
+static void AL_HikkoshiMenuDisplayer(ObjectMaster* a1) {
 	*(char*)0x25EFFCC = 0;
 
 	//DrawChaoHudThingB(MenuArray[2], 472, 399, -1.2f, 1, 1, 0, 0); //the middle arrow thing
@@ -300,13 +315,13 @@ void AL_HikkoshiMenuDisplayer(ObjectMaster* a1) {
 	*(char*)0x25EFFCC = 1;
 }
 
-void AL_HikkoshiMenu() {
+static void AL_HikkoshiMenu() {
 	ObjectMaster* a1 = LoadObject(3, "HikkoshiMenuExecutor", AL_HikkoshiMenuExecutor, LoadObj_Data1);
 	a1->DisplaySub = AL_HikkoshiMenuDisplayer;
 	a1->Data1.Entity->Scale.x = 0;
 }
 
-void AL_OdekakeMove(ODE_MENU_MASTER_WORK* a1) {
+static void AL_OdekakeMove(ODE_MENU_MASTER_WORK* a1) {
 	int previousSelected;
 
 	switch (a1->mode) {
@@ -392,28 +407,8 @@ void AL_OdekakeMove(ODE_MENU_MASTER_WORK* a1) {
 		}
 		break;
 	case 4:
-		// generic odekake destructor
-		AL_OdekakeMenuMaster_Data_ptr->NextStage = 0;
-		if (AL_OdekakeMenuMaster_Data_ptr)
-		{
-			void(__cdecl * v0)(ODE_MENU_MASTER_WORK*); // eax
-			v0 = AL_OdekakeMenuMaster_Data_ptr->mfStageExit;
-			if (v0)
-			{
-				//	v0(AL_OdekakeMenuMaster_Data_ptr);
-			}
-			AL_OdekakeMenuMaster_Data_ptr->PreStage = AL_OdekakeMenuMaster_Data_ptr->CurrStage;
-			AL_OdekakeMenuMaster_Data_ptr->CurrStage = AL_OdekakeMenuMaster_Data_ptr->NextStage;
-			AL_OdekakeMenuMaster_Data_ptr->mode = 0;
-			AL_OdekakeMenuMaster_Data_ptr->timer = 0;
-			AL_OdekakeMenuMaster_Data_ptr->subtimer = 0;
-			AL_OdekakeMenuMaster_Data_ptr->state = 0;
-			AL_OdekakeMenuMaster_Data_ptr->cursorX = 0;
-			AL_OdekakeMenuMaster_Data_ptr->cursorY = 2;
-			AL_OdekakeMenuMaster_Data_ptr->EndFlag = 0;
-			AL_OdekakeMenuMaster_Data_ptr->mfStageExit = 0;
-			AL_OdekakeMenuMaster_Data_ptr->mpStageWork = 0;
-		}
+		AL_OdeMenuSetNextStage(0);
+		AL_OdeMenuChangeStage();
 		break;
 	case 5:
 		// todo: use al_msg_warn.h functions for this

--- a/CWE/al_ode_menu.h
+++ b/CWE/al_ode_menu.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <cwe_api.h>
+
+// the generic sprite array used throughout the menus, a couple of our menu entries use it too
+DataArray(ChaoHudThingB, stru_11BA528, 0x11BA528, 30);
+
+static void AL_OdeMenuSetNextStage(int stage) {
+    if (AL_OdekakeMenuMaster_Data_ptr) {
+        AL_OdekakeMenuMaster_Data_ptr->NextStage = stage;
+    }
+}
+
+VoidFunc(AL_OdeMenuChangeStage, 0x57E680);
+
+extern CWE_API_ODEKAKE_ENTRY OdekakeCustomizationEntry;
+extern CWE_API_ODEKAKE_ENTRY OdakakeMoveEntry;
+extern CWE_API_ODEKAKE_ENTRY OdekakeNameEntry;
+extern CWE_API_ODEKAKE_ENTRY OdekakeGuestEntry;

--- a/CWE/al_ode_nazukeya.cpp
+++ b/CWE/al_ode_nazukeya.cpp
@@ -5,22 +5,34 @@
 #include "ninja_functions.h"
 #include <cstdio>
 
+#include "al_ode_menu.h"
+#include "al_texlist.h"
+
+static ChaoHudThingB NameMenuSprites[] = {
+	{1, 128, 32, 0, 0.01f, 0.5f, 0.5f, &NAME_ODE_TEXLIST, 0}, //text
+	{1, 128, 32, 136.0f / 256.0f, 0.01f, 1, 0.5f, &NAME_ODE_TEXLIST, 0}, //grey text
+	{1, 32, 32, 0.01f, 0.01f, 0.99f, 1, &NAME_ODE_TEXLIST, 1} //icon
+};
+
+static void AL_OdekakeName(ODE_MENU_MASTER_WORK* a1);
+
+CWE_API_ODEKAKE_ENTRY OdekakeNameEntry = { AL_OdekakeName, nullptr, ODE_FLAGS_REQUIRE_CHAO, &NameMenuSprites[2], &NameMenuSprites[0], &NameMenuSprites[1], nullptr, nullptr };
+
 char NazukeyaBuff[0x60 + 4 + sizeof(AL_NAME)];
 ObjectMaster* nazukeyaObj = 0;
 FunctionPointer(void, sub_5827A0, (int a1), 0x5827A0);
-void __cdecl Nazukeya_Main(ObjectMaster *a1)
-{
+
+static void Nazukeya_Main(ObjectMaster *a1) {
 	sub_582F60((char*)NazukeyaBuff);
 }
-void __cdecl Nazukeya_Display(ObjectMaster *a1)
-{
+
+static void Nazukeya_Display(ObjectMaster *a1) {
 	sub_5827A0((int)NazukeyaBuff);
 }
 
 //asdsd
 FunctionPointer(int, njReleaseTexture, (NJS_TEXLIST* arg0), 0x0077F9F0);
-void AL_OdekakeName(ODE_MENU_MASTER_WORK* a1)
-{
+static void AL_OdekakeName(ODE_MENU_MASTER_WORK* a1) {
 	int v4;
 	switch (a1->mode)
 	{
@@ -57,27 +69,8 @@ void AL_OdekakeName(ODE_MENU_MASTER_WORK* a1)
 		}
 		break;
 	case 2:
-		AL_OdekakeMenuMaster_Data_ptr->NextStage = 0;
-		if (AL_OdekakeMenuMaster_Data_ptr)
-		{
-			void(__cdecl * v0)(ODE_MENU_MASTER_WORK*); // eax
-			v0 = AL_OdekakeMenuMaster_Data_ptr->mfStageExit;
-			if (v0)
-			{
-				//	v0(AL_OdekakeMenuMaster_Data_ptr);
-			}
-			AL_OdekakeMenuMaster_Data_ptr->PreStage = AL_OdekakeMenuMaster_Data_ptr->CurrStage;
-			AL_OdekakeMenuMaster_Data_ptr->CurrStage = AL_OdekakeMenuMaster_Data_ptr->NextStage;
-			AL_OdekakeMenuMaster_Data_ptr->mode = 0;
-			AL_OdekakeMenuMaster_Data_ptr->timer = 0;
-			AL_OdekakeMenuMaster_Data_ptr->subtimer = 0;
-			AL_OdekakeMenuMaster_Data_ptr->state = 0;
-			AL_OdekakeMenuMaster_Data_ptr->cursorX = 0;
-			AL_OdekakeMenuMaster_Data_ptr->cursorY = 2;
-			AL_OdekakeMenuMaster_Data_ptr->EndFlag = 0;
-			AL_OdekakeMenuMaster_Data_ptr->mfStageExit = 0;
-			AL_OdekakeMenuMaster_Data_ptr->mpStageWork = 0;
-		}
+		AL_OdeMenuSetNextStage(0);
+		AL_OdeMenuChangeStage();
 		break;
 	}
 }

--- a/CWE/al_ode_storage.cpp
+++ b/CWE/al_ode_storage.cpp
@@ -8,6 +8,8 @@
 #include "al_sandhole.h"
 #include "memory.h"
 
+#include "al_ode_menu.h"
+
 #include <fstream>
 
 void someUIProjectionCode(NJS_VECTOR* a1, NJS_VECTOR* a2);
@@ -198,27 +200,8 @@ void AL_OdekakeStorage(ODE_MENU_MASTER_WORK* a1)
 	case 1:
 		break;
 	case 2:
-		AL_OdekakeMenuMaster_Data_ptr->NextStage = 0;
-		if (AL_OdekakeMenuMaster_Data_ptr)
-		{
-			void(__cdecl * v0)(ODE_MENU_MASTER_WORK*); // eax
-			v0 = AL_OdekakeMenuMaster_Data_ptr->mfStageExit;
-			if (v0)
-			{
-				//	v0(AL_OdekakeMenuMaster_Data_ptr);
-			}
-			AL_OdekakeMenuMaster_Data_ptr->PreStage = AL_OdekakeMenuMaster_Data_ptr->CurrStage;
-			AL_OdekakeMenuMaster_Data_ptr->CurrStage = AL_OdekakeMenuMaster_Data_ptr->NextStage;
-			AL_OdekakeMenuMaster_Data_ptr->mode = 0;
-			AL_OdekakeMenuMaster_Data_ptr->timer = 0;
-			AL_OdekakeMenuMaster_Data_ptr->subtimer = 0;
-			AL_OdekakeMenuMaster_Data_ptr->state = 0;
-			AL_OdekakeMenuMaster_Data_ptr->cursorX = 0;
-			AL_OdekakeMenuMaster_Data_ptr->cursorY = 2;
-			AL_OdekakeMenuMaster_Data_ptr->EndFlag = 0;
-			AL_OdekakeMenuMaster_Data_ptr->mfStageExit = 0;
-			AL_OdekakeMenuMaster_Data_ptr->mpStageWork = 0;
-		}
+		AL_OdeMenuSetNextStage(0);
+		AL_OdeMenuChangeStage();
 		break;
 	}
 }

--- a/CWE/al_odekake.cpp
+++ b/CWE/al_odekake.cpp
@@ -9,20 +9,21 @@
 #include "al_ode_guide.h"
 
 #include "cwe_api.h"
+#include <al_ode_menu.h>
 
+// todo: move this maybe somewhere more appropriate
 std::vector<CWE_API_ODEKAKE_ENTRY> odekakeMenuEntries;
 
 void AL_OdekakeMove(ODE_MENU_MASTER_WORK* a1);
 void AL_OdekakeName(ODE_MENU_MASTER_WORK* a1);
 void AL_OdekakeStorage(ODE_MENU_MASTER_WORK* a1);
-
 void __cdecl AL_OdekakeCustomization(ODE_MENU_MASTER_WORK* a1);
-void __cdecl AL_OdekakeGoodbye(ODE_MENU_MASTER_WORK* a1)
-{
+
+void AL_OdekakeGoodbye(ODE_MENU_MASTER_WORK* a1) {
 	sub_5A6F50(a1);
 }
-void __cdecl AL_OdekakeMenuMaster_(ObjectMaster* a1)
-{
+
+void __cdecl AL_OdekakeMenuMaster_(ObjectMaster* a1) {
 	ODE_MENU_MASTER_WORK* pOde = AL_OdekakeMenuMaster_Data_ptr;
 	int stage = pOde->CurrStage;
 
@@ -36,19 +37,15 @@ void __cdecl AL_OdekakeMenuMaster_(ObjectMaster* a1)
 	}
 	pOde->state = 0;
 }
-ChaoDataBase* __cdecl GBAManager_GetChaoDataPointer() {
-	ChaoDataBase* result; // eax
 
-	if (AL_GBAManagerExecutor_ptr)
-	{
-		result = (ChaoDataBase*) * ((int*)AL_GBAManagerExecutor_ptr + 5);
+ChaoDataBase* GBAManager_GetChaoDataPointer() {
+	if (!AL_GBAManagerExecutor_ptr) {
+		return nullptr;
 	}
-	else
-	{
-		result = 0;
-	}
-	return result;
+	
+	return (ChaoDataBase*)*((int*)AL_GBAManagerExecutor_ptr + 5);
 }
+
 DataPointer(int, Odekake_EnabledButtons, 0x01DB1020);
 FunctionPointer(void, sub_5AC390, (char a1, float a2, float a3, __int16 a4, int* a5), 0x5AC390);
 int Odekake_EnabledButtonsCWE[255] = { 0 }; //big placeholder buffer, ill decide a max size at some point
@@ -59,8 +56,7 @@ bool AL_OdekakeIsGuest() {
 	return Odekake_EnabledButtons && pParam && pParam->field_19 == 1;
 }
 
-void __cdecl AL_OdekakeButtons(char a1, float a2, float a3, __int16 a4, int* a5)
-{
+void __cdecl AL_OdekakeButtons(char a1, float a2, float a3, __int16 a4, int* a5) {
 	int isThereChao = Odekake_EnabledButtons;
 	bool guest = AL_OdekakeIsGuest();
 
@@ -81,7 +77,6 @@ void __cdecl AL_OdekakeButtons(char a1, float a2, float a3, __int16 a4, int* a5)
 	CreateButtonGuide(SELECT | CONFIRM | BACK);
 }
 
-DataArray(ChaoHudThingB, stru_11BA528, 0x11BA528, 30);
 ObjectFunc(sub_5AC010,0x5AC010);
 void NewButtonDraw(ObjectMaster *a1)
 {
@@ -186,37 +181,11 @@ void BarDraw(ObjectMaster* a1)
 	NewBarDraw(a1);
 }
 
-FunctionPointer(void, LoadNextChaoLevel, (int a1), 0x0052B5B0);
-void __cdecl AL_OdekakeQuit(ODE_MENU_MASTER_WORK*)
-{
-	LoadNextChaoLevel(LastChaoArea);
-	PlaySoundProbably(32787, 0, 0, 0);
-}
-
-// what a consistent naming scheme (and i won't fix it because i honestly don't know what to decide on with all our globals)
-ChaoHudThingB nameMenu[] = {
-	{1, 128, 32, 0, 0.01f, 0.5f, 0.5f, &NAME_ODE_TEXLIST, 0}, //text
-	{1, 128, 32, 136.0f / 256.0f, 0.01f, 1, 0.5f, &NAME_ODE_TEXLIST, 0}, //grey text
-	{1, 32, 32, 0.01f, 0.01f, 0.99f, 1, &NAME_ODE_TEXLIST, 1} //icon
-};
-
-ChaoHudThingB GuestMenu[] = {
-	{1, 128, 32, 0, 0.01f, 0.5f, 0.5f, &AL_ODE_GUEST_TEXLIST, 0}, //text
-	{1, 128, 32, 136.0f / 256.0f, 0.01f, 1, 0.5f, &AL_ODE_GUEST_TEXLIST, 0}, //grey text
-	{1, 40, 40, 0, 0, 0.99f, 1, &AL_ODE_GUEST_TEXLIST, 1}, //icon
-	{1, 48, 48, 0, 0, 0.99f, 1, &AL_ODE_GUEST_TEXLIST, 2}, //icon black and white
-};
-
-
-extern void AL_OdekakeGuest(ODE_MENU_MASTER_WORK* a1);
-static CWE_API_ODEKAKE_ENTRY goodbyeEntry = { AL_OdekakeGoodbye, nullptr, ODE_FLAGS_REQUIRE_CHAO, &stru_11BA528[33],&stru_11BA528[10],&stru_11BA528[11],&stru_11BA528[24],&stru_11BA528[25], 1.0, 0.0, 0.7265625, 0.74609375 };
-static CWE_API_ODEKAKE_ENTRY nameEntry = {AL_OdekakeName, nullptr, ODE_FLAGS_REQUIRE_CHAO, &nameMenu[2],&nameMenu[0],&nameMenu[1],nullptr,nullptr };
-static CWE_API_ODEKAKE_ENTRY moveEntry = { AL_OdekakeMove, nullptr, ODE_FLAGS_REQUIRE_NO_CHAO , &stru_11BA528[31],&stru_11BA528[6],&stru_11BA528[7],&stru_11BA528[20],&stru_11BA528[21], 1.0, 1.0, 0.5, 0.0 };
-static CWE_API_ODEKAKE_ENTRY customizationEntry = { AL_OdekakeCustomization, nullptr, ODE_FLAGS_REQUIRE_CHAO, &stru_11BA528[32],&stru_11BA528[8],&stru_11BA528[9],&stru_11BA528[22],&stru_11BA528[23], 1.0, 1.0, 0.5, 0.5 };
-static CWE_API_ODEKAKE_ENTRY guestEntry = { AL_OdekakeGuest, nullptr, ODE_FLAGS_REQUIRE_CHAO, &GuestMenu[2],&GuestMenu[0],&GuestMenu[1],&GuestMenu[3] , &GuestMenu[0], 1.0, 1.0, 0.5, 0.5 };
+// todo: maybe move these somewhere more findable?
+static CWE_API_ODEKAKE_ENTRY OdekakeGoodbyeEntry = { AL_OdekakeGoodbye, nullptr, ODE_FLAGS_REQUIRE_CHAO, &stru_11BA528[33],&stru_11BA528[10],&stru_11BA528[11],&stru_11BA528[24],&stru_11BA528[25], 1.0, 0.0, 0.7265625, 0.74609375 };
 
 // the quit entry is basically dummied out (except for the button sprites), because the menu is hardcoded to exit on the last button, so no functionality is needed for it
-static CWE_API_ODEKAKE_ENTRY quitEntry = { nullptr, nullptr, ODE_FLAGS_NONE, &stru_11BA528[34],&stru_11BA528[12],&stru_11BA528[13],nullptr,nullptr };
+static CWE_API_ODEKAKE_ENTRY OdekakeQuitEntry = { nullptr, nullptr, ODE_FLAGS_NONE, &stru_11BA528[34],&stru_11BA528[12],&stru_11BA528[13],nullptr,nullptr };
 
 void GoodbyeBar()
 {
@@ -268,7 +237,7 @@ void AddOdekakeMenu(const CWE_API_ODEKAKE_ENTRY& entry) {
 void AL_Odekake_Finalize() {
 	// this should be the last button in the menu, always
 	// it's unnecessary to have this in a separate function but i didn't know any other way to "categorize" these types of changes
-	odekakeMenuEntries.push_back(quitEntry);
+	odekakeMenuEntries.push_back(OdekakeQuitEntry);
 }
 
 void AL_Odekake_Update() {
@@ -306,15 +275,15 @@ void AL_Odekake_Init()
 
 	odekakeMenuEntries.clear();
 	//if(cweSaveFile.transporterFlag & eTRANSPORTER::NAME)
-		odekakeMenuEntries.push_back(nameEntry);
+		odekakeMenuEntries.push_back(OdekakeNameEntry);
 	//if (cweSaveFile.transporterFlag & eTRANSPORTER::MOVE)
-		odekakeMenuEntries.push_back(moveEntry);
+		odekakeMenuEntries.push_back(OdakakeMoveEntry);
 	//if (cweSaveFile.transporterFlag & eTRANSPORTER::CUSTOMIZATION)
-		odekakeMenuEntries.push_back(customizationEntry);
+		odekakeMenuEntries.push_back(OdekakeCustomizationEntry);
 
-	odekakeMenuEntries.push_back(guestEntry);
+	odekakeMenuEntries.push_back(OdekakeGuestEntry);
 		
-	odekakeMenuEntries.push_back(goodbyeEntry);
+	odekakeMenuEntries.push_back(OdekakeGoodbyeEntry);
 
 	WriteData((char*)0x005AC2BE, (char)30); //displayfixes
 	WriteData((char*)0x005AC259, (char)4);


### PR DESCRIPTION
Menus use the AL_OdeMenuChangeStage/SetNextStage functions in their closing segments now to not have the same inlined code everywhere, and the menu entries are now moved to the files where the menu code is.